### PR TITLE
Add custom CSS option - fixes issue #14

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -43,6 +43,12 @@
 	<link rel="stylesheet" type="text/css" media="screen" href="{{ .Site.BaseURL }}css/main.css" />
 	{{- if or (eq .Site.Params.mode "auto") (eq .Site.Params.mode "dark") -}}
 		<link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}css/dark.css" {{ if eq .Site.Params.mode "auto" }}media="(prefers-color-scheme: dark)"{{ end }} />
+	{{ end }}
+	<!-- Custom CSS style get applied last -->
+	{{- if isset .Site.Params "customcss" }}
+		{{ range .Site.Params.customCSS }}
+		<link rel="stylesheet" type="text/css" ref="{{ . | relURL }}">
+		{{ end }}
 	{{- end -}}
 	{{- range .Site.Params.customJS }}
 	{{- if or (hasPrefix . "http://") (hasPrefix . "https://") }}


### PR DESCRIPTION
Borrowed some code from https://github.com/gadenbuie/garrickadenbuie-com/blob/main/layouts/partials/head.html and blended it in. I hope the syntax is still valid and makes sense. I'm not sure if it ought to say `if isset .Site.Params "customCSS"` but I left it as `customcss` as you suggested.