### PR TITLE
fix unwanted star before nested ordered list

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -60,7 +60,7 @@ ul {
 ul li {
   text-indent: -2ch;
 }
-ul li::before {
+ul > li::before {
   content: '* ';
   font-weight: bold;
 }


### PR DESCRIPTION
markdown:

```
* xxx
* yyy
  1. aaa
  2. bbb
  3. ccc
```

before:

<img width="105" alt="image" src="https://user-images.githubusercontent.com/4198311/106356576-aa851200-633b-11eb-830b-75aa290441fb.png">

after:

<img width="105" alt="image" src="https://user-images.githubusercontent.com/4198311/106356588-be307880-633b-11eb-82ff-00e1a93fbf07.png">

