### PR TITLE
Add support for meta descriptions

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,7 +14,9 @@
 	{{- end -}}
 
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-
+	{{- if isset .Site.Params "description" }}
+	<meta name="description" content="{{ .Site.Params.description }}" />
+	{{- end }}
 	<meta property="og:image" content="{{ .Site.Params.og_image }}"/>
 	{{ with .OutputFormats.Get "rss" -}}
 	{{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}


### PR DESCRIPTION
The meta description tag is _allegedly_ important for SEO, and it can improve the page's summary in Google results.