### PR TITLE
Improve meta description

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,9 +14,7 @@
 	{{- end -}}
 
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	{{- if isset .Site.Params "description" }}
-	<meta name="description" content="{{ .Site.Params.description }}" />
-	{{- end }}
+	<meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
 	<meta property="og:image" content="{{ .Site.Params.og_image }}"/>
 	{{ with .OutputFormats.Get "rss" -}}
 	{{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}


### PR DESCRIPTION
@athul Sorry for the multiple PRs, I jumped the gun on the last one and wasn't really expecting such a fast turnaround on the original PR. 🤐  After looking into it more, it makes more sense to provide a custom meta description per-page where possible, so I copied the behavior of the `og:description` tag.

-----

Rather than use the same description on every page, prefer the post summary if it's available and only use .Params.description on the root page.

This mimics the behavior of the [opengraph internal template](https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/opengraph.html#L2) for the `og:description` tag.