### PR TITLE
fix for dark/light mode toggle when not using CDN

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,7 +24,7 @@
 	{{- template "_internal/twitter_cards.html" . -}}
 	{{ if and (isset .Site.Params "social") (.Site.Params.useCDN | default false) -}}
 		<script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
-	{{- else if (isset .Site.Params "social") -}}
+	{{- else if or (isset .Site.Params "social") (in .Site.Params.mode "toggle") -}}
 		<script src="{{ .Site.BaseURL }}js/feather.min.js"></script>
 	{{ end }}
 	{{ if .Site.Params.useCDN | default false -}}


### PR DESCRIPTION
Feather icons are also needed for displaying the dark/light mode switch. Currently they are not loaded if the user chooses to not use CDN, and doesn't put any link to social media in the footer. Otherwise the toggle is not displayed.
This fix checks for dark/light mode set to "toggle", and loads the icon pack when needed