### PR TITLE
fix for dark/light mode toggle when not using CDN

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-custom: https://www.buymeacoffee.com/athulca

--- a/README.md
+++ b/README.md
@@ -1,14 +1,8 @@
-# Archie - Hugo theme
-Archie is a minimal and clean theme for hugo with a markdown-ish UI.
+# ArchieType - Hugo theme
+ArchieType is a fork of [Archie](https://github.com/athul/archie) theme by Athul Cyriac Ajay
 
-Forked from [Ezhil Theme](https://github.com/vividvilla/ezhil)
+Please check out the original repository for demo website and sample config.
 
-## Demo
-
-[Check the Demo](https://athul.github.io/archie/) hosted on GitHub Pages :smile: . You can find the source code to that in the `site` branch of this repository
-
-![](/images/theme.png)
-![](/images/archie-dark.png)
 ## Feature
 - Google Analytics Script
 - Callouts
@@ -19,31 +13,15 @@ Forked from [Ezhil Theme](https://github.com/vividvilla/ezhil)
 - Cache busting for CSS files
 
 ## Installation
-In your Hugo website directory, create a new folder named theme and clone the repo
-```bash
-$ mkdir themes
-$ cd themes
-$ git clone https://github.com/athul/archie.git
+Go to your Hugo site directory and add the following
 ```
-Edit the `config.toml` file with `theme="archie"`
+git submodule add https://github.com/marbuka/archietype.git themes/archietype
+```
+Edit the `config.toml` file with `theme="archietype"`
 For more information read the official [setup guide](https://gohugo.io/overview/installing/) of Hugo.
 
-## Writing Posts
-Create a new `.md` file in the *content/posts* folder
-```yml
----
-title: Title of the post
-description:
-date:
-tldr: (optional)
-draft: true/false (optional)
-tags: [tag names] (optional)
----
-```
-
 ## Credits
-Forked from [Ezhil Theme](https://github.com/vividvilla/ezhil) and Licensed under MIT License
-Inspired by design of blog.jse.li
+Forked from [Archie Theme](https://github.com/athul/archie) and Licensed under MIT License
 
 ----
 
@@ -58,69 +36,3 @@ Note: CSS files should be placed under the `assets` directory e.g. `assets/css/f
 [params]
 	customcss = ["css/first.css", "css/second.css"]
 ```
-
-
-## Config of the Demo Site
-
-```toml
-baseURL = "https://athul.github.io/archie/"
-languageCode = "en-us"
-title = "Archie"
-theme="archie"
-copyright = "© Athul"
-# Code Highlight
-pygmentsstyle = "monokai"
-pygmentscodefences = true
-pygmentscodefencesguesssyntax = true
-
-paginate=3 # articles per page
-
-[params]
-	mode="auto" # color-mode → light,dark,toggle or auto
-	useCDN=false # don't use CDNs for fonts and icons, instead serve them locally.
-	subtitle = "Minimal and Clean [blog theme for Hugo](https://github.com/athul/archie)"
-
-# Social Tags
-
-[[params.social]]
-name = "GitHub"
-icon = "github"
-url = "https://github.com/athul/archie"
-
-[[params.social]]
-name = "Twitter"
-icon = "twitter"
-url = "https://twitter.com/athulcajay/"
-
-[[params.social]]
-name = "GitLab"
-icon = "gitlab"
-url = "https://gitlab.com/athul/"
-
-# Main menu Items
-
-[[menu.main]]
-name = "Home"
-url = "/"
-weight = 1
-
-[[menu.main]]
-name = "All posts"
-url = "/posts"
-weight = 2
-
-[[menu.main]]
-name = "About"
-url = "/about"
-weight = 3
-
-[[menu.main]]
-name = "Tags"
-url = "/tags"
-weight = 4
-```
----
-
-If you liked my work please consider supporting me on [BuymeACoffee](https://www.buymeacoffee.com/athulca)
-
-<a href="https://www.buymeacoffee.com/athulca" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-red.png" alt="Buy Me A Coffee" height="41" width="174" ></a>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,7 @@
 {{ if isset .Data "Term" }}
 <h1>Entries tagged - "{{ .Data.Term }}"</h1>
 {{ else }}
-<h1 class="page-title">All articles</h1>
+<h1 class="page-title">All notes</h1>
 {{ end }}
 
 <ul class="posts">

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -2,7 +2,7 @@
 {{ if isset .Data "Term" }}
 <h1>Entries tagged - "{{ .Data.Term }}"</h1>
 {{ else }}
-<h1 class="page-title">All articles</h1>
+<h1 class="page-title">All notes</h1>
 {{ end }}
 
 <ul class="posts">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,8 +2,8 @@
 <hr>
 {{- range $index, $key := .Site.Params.Social -}}
 <a class="soc" href="{{ $key.url }}" title="{{ $key.name }}"><i data-feather="{{ $key.icon }}"></i></a>|
-{{- end -}} ⚡️
-	{{ dateFormat "2006" now }} {{ with .Site.Copyright }} {{ . }} | {{ end }} <a href="https://github.com/athul/archie">Archie Theme</a> | Built with <a href="https://gohugo.io">Hugo</a>
+{{- end -}} 
+	{{ dateFormat "2006" now }} {{ with .Site.Copyright }} {{ . }} | {{ end }} <a href="https://github.com/marbuka/archietype">ArchieType Theme</a> | Built with <a href="https://gohugo.io">Hugo</a>
 </footer>
 {{ if not .Site.IsServer }}
 {{ template "_internal/google_analytics_async.html" . }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,7 +24,7 @@
 	{{- template "_internal/twitter_cards.html" . -}}
 	{{ if and (isset .Site.Params "social") (.Site.Params.useCDN | default false) -}}
 		<script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
-	{{- else if or (isset .Site.Params "social") (in .Site.Params.mode "toggle") -}}
+	{{- else if or (isset .Site.Params "social") (eq .Site.Params.mode "toggle") -}}
 		<script src="{{ .Site.BaseURL }}js/feather.min.js"></script>
 	{{ end }}
 	{{ if .Site.Params.useCDN | default false -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,7 +24,7 @@
 	{{- template "_internal/twitter_cards.html" . -}}
 	{{ if and (isset .Site.Params "social") (.Site.Params.useCDN | default false) -}}
 		<script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
-	{{- else if (isset .Site.Params "social") -}}
+	{{- else if or (isset .Site.Params "social") (in .Site.Params.mode "toggle") -}}
 		<script src="{{ .Site.BaseURL }}js/feather.min.js"></script>
 	{{ end }}
 	{{ if .Site.Params.useCDN | default false -}}

--- a/theme.toml
+++ b/theme.toml
@@ -1,15 +1,15 @@
 # theme.toml template for a Hugo theme
 # See https://github.com/gohugoio/hugoThemes#themetoml for an example
 
-name = "Archie"
+name = "ArchieType"
 license = "MIT"
-licenselink = "https://github.com/athul/archie/blob/master/LICENSE"
+licenselink = "https://github.com/marbuka/archietype/blob/master/LICENSE"
 description = "Archie is a minimal and clean theme for hugo with a markdown-ish UI."
-homepage = "https://github.com/athul/archie"
+homepage = "https://github.com/marbuka/archietype"
 tags = ["blog","simple","responsive","minimal","tags","personal","clean","shortcodes"]
 features = ["blog", "Clean and minimal", "Responsive", "Syntax highlighting",]
 min_version = "0.41"
 
 [author]
-  name = "Athul Cyriac Ajay"
-  homepage = "https://github.com/athul"
+  name = "MBK
+  homepage = "https://github.com/marbuka"


### PR DESCRIPTION
The dark/light mode switch also needs Feather icons to load. Currently if not using CDN they are loaded only when there are links to social media in the footer. The fix checks also if the dark/light mode is set to "toggle".