### PR TITLE
Added <script> tag support and a readmore class to the readmore links

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -24,7 +24,7 @@
 						{{ .Summary }}&hellip;
 						{{ end }}
 					</div>
-					<a href="{{ .RelPermalink }}">Read more ⟶</a>
+					<a class="readmore" href="{{ .RelPermalink }}">Read more ⟶</a>
 				</section>
 				{{ end }}
 				{{ template "partials/paginator.html" . }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -54,6 +54,8 @@
 	{{- range .Site.Params.customJS }}
 	{{- if or (hasPrefix . "http://") (hasPrefix . "https://") }}
 	<script src="{{ . }}"></script>
+	{{- else if (hasPrefix . "<script")}}
+    {{ .| safeHTML }}
 	{{- else }}
 	<script src="{{ $.Site.BaseURL }}{{ . }}"></script>
 	{{- end }}


### PR DESCRIPTION
Updated ```headers.html``` to allow <script> tags to be added to the ```<head>``` element, similar to [gokarna](https://github.com/526avijitgupta/gokarna).

```taml
[params]
	mode="auto"
	useCDN=false
	subtitle = "Minimal and Clean [blog theme for Hugo](https://github.com/athul/archie)"
	customJS = ["<script>console.log('JavaScript');</script>"]
```

Added the "readmore" class to the Read More links in the ```index.html``` page, they can then be styled separately from the other ```<a>``` elements. For example setting the border to be dotted:

![image](https://user-images.githubusercontent.com/4988413/155876204-3197b80e-fbec-4e6a-825d-ad2635e94c5a.png)
