### PR TITLE
chore: Change CSS for Socials in Footer again

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -171,10 +171,12 @@ footer {
 .soc {
   display: flex;
   align-items: center;
-  padding-right: 1rem;
-  margin-right: 1rem;
-  border-right: 2px solid;
   border-bottom: none;
+}
+.border {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  border: 1px solid;
 }
 .footer-info {
   padding: var(--footer-padding);

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,6 +2,7 @@
   <div style="display:flex">
     {{- range $index, $key := .Site.Params.Social -}}
     <a class="soc" href="{{ $key.url }}" title="{{ $key.name }}"><i data-feather="{{ $key.icon }}"></i></a>
+    <a class="border"></a>
     {{- end -}}
   </div>
   <div class="footer-info">


### PR DESCRIPTION
Hello, I found that the width between icons in the latest footer is a bit too large. Also, when the mouse hovers over the icon, its shadow part will contain the padding on the right side, which is not beautiful.

![image-20220625111745518](https://user-images.githubusercontent.com/58338486/175756339-c1e062bc-3ba1-4fda-84fd-99f4cf08626f.png)

So I made some changes and the changed footer is as follows.

![image-20220625111917016](https://user-images.githubusercontent.com/58338486/175756430-e873d353-1aad-420a-b393-c3ea2c320904.png)
