### PR TITLE
Fixed title and menu links overlap in header

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -138,6 +138,7 @@ header {
   flex-wrap: wrap;
   justify-content: space-between;
   margin: 1em 0;
+  line-height: 2.5em;
 }
 
 header .main {


### PR DESCRIPTION
From this:
![image](https://user-images.githubusercontent.com/2121715/184247323-e1a29bfd-a573-4951-829f-5d19b13fcda3.png)

To this:
![image](https://user-images.githubusercontent.com/2121715/184247273-3b9a0a17-450b-4114-8b42-4ed9c051801b.png)

Fixes #53 