### PR TITLE
fix: no need to reload for theme change

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,7 +7,7 @@
 		<a href="{{ .URL }}">{{ .Name }}</a>
 		{{ end }}
 		{{ if eq .Site.Params.mode "toggle" -}}
-        | <a id="dark-mode-toggle" onclick="toggleTheme()" href=""></a>
+        | <span id="dark-mode-toggle" onclick="toggleTheme()"></span>
 		<script src="{{ .Site.BaseURL }}js/themetoggle.js"></script>
 		{{ end }}
 	</nav>


### PR DESCRIPTION
Changing the theme using toggle does not require reloading the entire page using self-linking