### PR TITLE
Break out the page description from the 'index.html' layout

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,14 +17,7 @@
 				<section class="list-item">
 					<h1 class="title"><a href="{{ .RelPermalink }}">{{.Title}}</a></h1>
 					<time>{{ dateFormat "Jan 2, 2006" .Date }}{{ if .Draft }} <span class="draft-label">DRAFT</span> {{ end }}</time>
-					<br><div class="description">
-						{{ if isset .Params "description" }}
-						{{ .Description }}
-						{{ else }}
-						{{ .Summary }}&hellip;
-						{{ end }}
-					</div>
-					<a class="readmore" href="{{ .RelPermalink }}">Read more ⟶</a>
+					<br>{{ template "partials/pagedescription.html" . }}
 				</section>
 				{{ end }}
 				{{ template "partials/paginator.html" . }}

--- a/layouts/partials/pagedescription.html
+++ b/layouts/partials/pagedescription.html
@@ -1,0 +1,7 @@
+<div class="description">
+	{{ if isset .Params "description" }}
+	{{ .Description }}
+	{{ else }}
+	{{ .Summary }}&hellip;
+	{{ end }}
+</div>


### PR DESCRIPTION
This change breaks out the page description from the 'index.html' layout into its own partial - I'm using this on my blog to change the way the description is rendered without having to alter the theme itself.