### PR TITLE
Fix: display `Read more -->`

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,6 +18,7 @@
 					<h1 class="title"><a href="{{ .RelPermalink }}">{{.Title}}</a></h1>
 					<time>{{ dateFormat "Jan 2, 2006" .Date }}{{ if .Draft }} <span class="draft-label">DRAFT</span> {{ end }}</time>
 					<br>{{ template "partials/pagedescription.html" . }}
+					<a class="readmore" href="{{ .RelPermalink }}">Read more ⟶</a>
 				</section>
 				{{ end }}
 				{{ template "partials/paginator.html" . }}


### PR DESCRIPTION
`Read more --> ` element is gone by #71. so i fixed to display again.
ref: https://github.com/athul/archie/issues/72
