### PR TITLE
fixed tag link to be more robust

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -21,7 +21,7 @@
 			<nav class="nav tags">
 				<ul class="tags">
 					{{ range .Params.tags }}
-					<li><a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a></li>
+					<li><a href="{{ "tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a></li>
 					{{ end }}
 				</ul>
 			</nav>


### PR DESCRIPTION
this changes the tag link to work on sites installed on sub-directory, such as "/linux". Removing the leading slash makes this work, though I must admit I don't know why, as I'm relatively new to Hugo. I tested this out on my own site and it works.