### PR TITLE
Fix compatibility with Hugo v0.125.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ $ git clone https://github.com/athul/archie.git
 Edit the `config.toml` file with `theme="archie"`
 For more information read the official [setup guide](https://gohugo.io/installation/) of Hugo.
 
+If you encounter any issues with Google Analytics, update Hugo to v0.125.0 or
+later and make sure your using the latest version of the theme.
+
 ## Writing Posts
 Create a new `.md` file in the *content/posts* folder
 ```yml

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -11,7 +11,7 @@
   </div>
 </footer>
 {{ if not .Site.IsServer }}
-{{ template "_internal/google_analytics_async.html" . }}
+{{ template "_internal/google_analytics.html" . }}
 {{ end }}
 
 {{- if (isset .Site.Params "social") -}}


### PR DESCRIPTION
`google_analytics_async.html` is now removed from Hugo and the regular template should be used.
Hugo pull-request: [#12299](https://github.com/gohugoio/hugo/pull/12299)

Without this change, it is not possible to build with Hugo v0.125.0 or later.