### PR TITLE
Process _index.md contents

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,8 @@
 {{ if isset .Data "Term" }}
 <h1>Entries tagged - "{{ .Data.Term }}"</h1>
 {{ else }}
-<h1 class="page-title">All articles</h1>
+<h1 class="page-title">{{ .Title }}</h1>
+{{ .Content }}
 {{ end }}
 
 <ul class="posts">

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,11 +8,9 @@
 
 <ul class="posts">
 	{{- range .Data.Pages -}}
-		{{- if (not (in (.Site.Params.excludedTypes | default (slice "page")) .Type)) -}}
 		<li class="post">
 			<a href="{{ .RelPermalink }}">{{.Title}}</a> <span class="meta">{{ dateFormat ":date_medium" .Date }}{{ if .Draft }} <span class="draft-label">DRAFT</span> {{ end }}</span>
 		</li>
-		{{- end -}}
 	{{- end -}}
 </ul>
 {{ end }}


### PR DESCRIPTION
Closes #128. Simply uses contents and title from an `_index.md` file for the list archetype.