### PR TITLE
Multilingual Aware Title Link

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -10,7 +10,7 @@
 
 <header>
 	<div class="main">
-		<a href="{{ absURL "/" }}">{{ .Site.Title }}</a>
+		<a href="{{ absLangURL "/" }}">{{ .Site.Title }}</a>
 	</div>
 	<nav>
 		{{ range .Site.Menus.main }}


### PR DESCRIPTION
Update title to use `absLangURL` instead of `absURL` in order to correctly navigate to translated home page.