### PR TITLE
Fixed a bug

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -32,7 +32,7 @@
       </div>
 
       <!-- TOC -->
-      {{ if isset .Params "toc" }}
+      {{ if and (isset .Params "toc") (.Params.toc) }}
       <div class="toc">
         <strong>Table of contents:</strong>
         {{ .TableOfContents }}


### PR DESCRIPTION
```
https://github.com/athul/archie?tab=readme-ov-file#writing-posts

toc: true/false (optional)
```
It says here that the value of “toc” can be either true or false, and in fact, even if it is false, the TOC will still be displayed on the page. 

The previous code only determines whether to display “toc” by whether it is defined or not, It should also be determined whether its value is true.