### PR TITLE
Add support for Twikoo

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -280,11 +280,11 @@ justify-content: space-between;
   content: "🏷 ";
 }
 .tags a{
-  border-bottom: 3px solid var(--maincolor); 
+  border-bottom: 3px solid var(--maincolor);
 }
 .tags a:hover{
   color:white;
-  background-color: var(--hovercolor); 
+  background-color: var(--hovercolor);
 }
 svg{
   max-height: 15px;
@@ -292,7 +292,7 @@ svg{
 .soc:hover{
   color: white;
 }
-.draft-label{ 
+.draft-label{
     color: var(--bordercl);
     text-decoration: none;
     padding: 2px 4px;
@@ -343,7 +343,7 @@ color:white
 .highlight pre code[class*='language-json']::before{
 content: 'json';
 background: dodgerblue;
- color: #000000 
+ color: #000000
 }
 .highlight pre code[class*='language-python']::before,
 .highlight pre code[class*='language-py']::before {
@@ -398,4 +398,10 @@ table td{
   stroke-linecap: round;
   stroke-linejoin: round;
   fill: none;
+}
+
+#tcomment {
+  margin-top: 2em;
+  padding-top: 2em;
+  border-top: 1px solid #eee;
 }

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -49,6 +49,21 @@
     {{- if eq ($.Scratch.Get "isDisqus") true -}}
     {{- partial "disqus.html" . -}}
     {{- end -}}
+
+    <!-- Twikoo -->
+    {{ $pagePath := .File.Path }}
+    {{ $disableComments := .Site.Params.disableComments | default slice }}
+    {{ if not (in $disableComments $pagePath) }}
+    <div id="tcomment"></div>
+    <script src="https://cdn.jsdelivr.net/npm/twikoo@1.6.41/dist/twikoo.min.js"></script>
+    <script>
+      twikoo.init({
+        envId: '{{ .Site.Params.twikoo.envId }}',
+        el: '#tcomment',
+      })
+    </script>
+    {{ end }}
+
   </article>
 </main>
 {{ end }}

--- a/theme.toml
+++ b/theme.toml
@@ -9,7 +9,13 @@ homepage = "https://github.com/athul/archie"
 tags = ["blog","simple","responsive","minimal","tags","personal","clean","shortcodes"]
 features = ["blog", "Clean and minimal", "Responsive", "Syntax highlighting",]
 min_version = "0.41"
+disableComments = ["about.md"]
 
 [author]
   name = "Athul Cyriac Ajay"
   homepage = "https://github.com/athul"
+
+# Comments
+
+[twikoo]
+    envId = "your-env-id"


### PR DESCRIPTION
Adds support for [Twikoo](https://twikoo.js.org/), a lightweight and powerful comment system.

Functions include a hugo parameter for Twikoo environment id and a blacklist for posts disabling comments.

Twikoo site itself is a live example. [Here](https://lofilog.com/posts/early-career-personal-finance-1/) is another example of Twikoo hosting with Archie theme.