### PR TITLE
exampleSite: fix error when running with hugo 0.146.3

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,11 +17,11 @@
 				<section class="list-item">
 					<h1 class="title"><a href="{{ .RelPermalink }}">{{.Title}}</a></h1>
 					<time>{{ dateFormat ":date_medium" .Date }}{{ if .Draft }} <span class="draft-label">DRAFT</span> {{ end }}</time>
-					<br>{{ template "partials/pagedescription.html" . }}
+					<br>{{ partial "pagedescription.html" . }}
 					<a class="readmore" href="{{ .RelPermalink }}">Read more ⟶</a>
 				</section>
 				{{ end }}
-				{{ template "partials/paginator.html" . }}
+				{{ partial "paginator.html" . }}
 			</main>
 			{{ partial "footer.html" . }}
 		</div>


### PR DESCRIPTION
When running example site with latest hugo version 0.146.3, errors are thrown:

```
Error: html/template:index.html:24:16: no such template "partials/paginator.html"
```

This PR fixes these issues.
For details, see https://github.com/gohugoio/hugo/issues/13582
