### PR TITLE
Optimized the display of default directory titles

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,5 +1,9 @@
 {{ define "main" }}
-<h1 class="page-title">All tags</h1>
+{{ if isset .Data "Term" }}
+<h1>Entries tagged - "{{ .Data.Term }}"</h1>
+{{ else }}
+<h1 class="page-title">All articles</h1>
+{{ end }}
 
 {{ $biggest := 1 }}
 {{ $smallest := 1 }}


### PR DESCRIPTION
When setting the default directory keyword "categories" for user articles, the title rendered on the page is displayed as "Categories" instead of "tags", which may confuse users unfamiliar with Hugo.

![image](https://github.com/user-attachments/assets/8f34a00c-8fd7-4026-ab1e-873d9ba68d1c)
