### PR TITLE
Fix tag spacing and add tag counts

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -525,6 +525,7 @@ article .title {
 
 .tags li::before {
   content: "🏷 ";
+  margin-inline-start: 2rem;
 }
 
 .tags a {

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -13,7 +13,7 @@
 		{{ range $key, $value := .Data.Terms.ByCount }}
 		{{ $size := (add (mul (div $value.Count $biggest) (sub $max $min)) $min) }}
 		{{ $size := (cond (eq $biggest $smallest) $min $size) }}
-		<li><a style="font-size: {{ $size }}rem;" href="{{ $.Site.LanguagePrefix | absURL }}{{ $data.Plural }}/{{ $value.Name | urlize }}/">{{ $value.Name }}</a></li>
+		<li><a style="font-size: {{ $size }}rem;" href="{{ $.Site.LanguagePrefix | absURL }}{{ $data.Plural }}/{{ $value.Name | urlize }}/">{{ $value.Name }} ({{ $value.Count }})</a></li>
 		{{ end }}
 	</ul>
 </div>


### PR DESCRIPTION
- Fix tag icon overlapping with previous content by adding margin-inline-start
- Add post count display to tags on the all tags page