### PR TITLE
Fix bug with site name link. The / symbol was removed.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -34,7 +34,7 @@
 
 <header>
 	<div class="main">
-		<a href="{{ absLangURL "/" }}">{{ .Site.Title }}</a>
+		<a href="{{ absLangURL "" }}">{{ .Site.Title }}</a>
 	</div>
 	<nav>
 		{{ range .Site.Menus.main }}


### PR DESCRIPTION
The / symbol was removed, causing the URL to be pasted incorrectly.

About this on official docs hugo: https://gohugo.io/functions/urls/abslangurl/