### PR TITLE
Fix: Improve social icons visibility on hover in both light and dark modes

### DIFF
--- a/assets/css/dark.css
+++ b/assets/css/dark.css
@@ -107,7 +107,6 @@ footer {
 
 .soc:hover,
 .soc:focus {
-  color: var(--color-primary-dark, #50fa7b);
   color: #000000;
   outline-color: var(--color-primary-dark, #50fa7b);
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -417,7 +417,6 @@ footer {
 
 .soc:hover,
 .soc:focus {
-  color: var(--color-primary, #dc143c);
   color: #ffffff;
   outline: 2px solid var(--color-primary, #dc143c);
   outline-offset: 2px;


### PR DESCRIPTION
Issue: Social icons gets hidden on hovering in both dark and light mode. This is due to the border filled color merges with the icon color. 

Fix:  Black color icons in light mode should change to white color on hover and white color icons in dark mode should turn to black color on hovering. 
Added contrasting color in CSS class handling social icons  hover & focus. 