### PR TITLE
Fixes #154: Add trailing slash to tag links in posts.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -22,7 +22,7 @@
           <nav class="nav tags">
             <ul class="tags">
               {{ range .Params.tags }}
-              <li><a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a></li>
+              <li><a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a></li>
               {{ end }}
             </ul>
           </nav>


### PR DESCRIPTION
See #154 for description. I did this for my site in an overridden layout, but it would be great to have it fixed in the base theme too. Thanks so much for sharing this theme!