### PR TITLE
fix: absolute URL for og:image

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -15,7 +15,7 @@
 
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
-	<meta property="og:image" content="{{ .Site.Params.og_image }}"/>
+	<meta property="og:image" content="{{ .Site.Params.og_image | absURL }}"/>
 	{{ with .OutputFormats.Get "rss" -}}
 	{{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
 	{{ end -}}


### PR DESCRIPTION
The user should not pass the absolute URL from their Hugo config file, since this would entail hard-coding the domain, thus breaking the dev environment at the very least.